### PR TITLE
fix handler is nil

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package gev
 
 import (
+	"errors"
 	"runtime"
 	"time"
 
@@ -33,6 +34,9 @@ type Server struct {
 
 // NewServer 创建 Server
 func NewServer(handler Handler, opts ...Option) (server *Server, err error) {
+	if handler == nil {
+		return nil,errors.New("handler is nil")
+	}
 	options := newOptions(opts...)
 	server = new(Server)
 	server.callback = handler


### PR DESCRIPTION
在方法
```
func NewServer(handler Handler, opts ...Option)
```
Handler是接口类型，为了避免业务使用的时候传入nil，在后续的处理才会出现:
```
panic: runtime error: invalid memory address or nil pointer dereference
```
