### PR TITLE
Recover `Connection.Context()`.

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -25,8 +25,6 @@ type CallBack interface {
 
 // Connection TCP 连接
 type Connection struct {
-	Context
-
 	fd        int
 	connected atomic.Bool
 	outBuffer *ringbuffer.RingBuffer // write buffer
@@ -34,6 +32,8 @@ type Connection struct {
 	callBack  CallBack
 	loop      *eventloop.EventLoop
 	peerAddr  string
+	ctx       interface{}
+	KeyValueContext
 
 	idleTime    time.Duration
 	activeTime  atomic.Int64
@@ -77,6 +77,16 @@ func (c *Connection) closeTimeoutConn() func() {
 			c.timingWheel.AfterFunc(c.idleTime-intervals, c.closeTimeoutConn())
 		}
 	}
+}
+
+// Context 获取 Context
+func (c *Connection) Context() interface{} {
+	return c.ctx
+}
+
+// SetContext 设置 Context
+func (c *Connection) SetContext(ctx interface{}) {
+	c.ctx = ctx
 }
 
 // PeerAddr 获取客户端地址信息

--- a/connection/context.go
+++ b/connection/context.go
@@ -2,37 +2,37 @@ package connection
 
 import "sync"
 
-type Context struct {
+type KeyValueContext struct {
 	mu sync.RWMutex
 
-	Keys map[string]interface{}
+	kv map[string]interface{}
 }
 
-func (c *Context) Set(key string, value interface{}) {
+func (c *KeyValueContext) Set(key string, value interface{}) {
 	c.mu.Lock()
-	if c.Keys == nil {
-		c.Keys = make(map[string]interface{})
+	if c.kv == nil {
+		c.kv = make(map[string]interface{})
 	}
 
-	c.Keys[key] = value
+	c.kv[key] = value
 	c.mu.Unlock()
 }
 
-func (c *Context) Delete(key string) {
+func (c *KeyValueContext) Delete(key string) {
 	c.mu.Lock()
-	delete(c.Keys, key)
+	delete(c.kv, key)
 	c.mu.Unlock()
 }
 
-func (c *Context) Get(key string) (value interface{}, exists bool) {
+func (c *KeyValueContext) Get(key string) (value interface{}, exists bool) {
 	c.mu.RLock()
-	value, exists = c.Keys[key]
+	value, exists = c.kv[key]
 	c.mu.RUnlock()
 	return
 }
 
-func (c *Context) reset() {
+func (c *KeyValueContext) reset() {
 	c.mu.Lock()
-	c.Keys = nil
+	c.kv = nil
 	c.mu.Unlock()
 }

--- a/connection/context_test.go
+++ b/connection/context_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestContext(t *testing.T) {
-	ctx := Context{}
+func TestKeyValueContext(t *testing.T) {
+	ctx := KeyValueContext{}
 
 	// Delete non-existent key
 	ctx.Delete("1")


### PR DESCRIPTION
Recover the old `ctx` to keep backward compatibility with the old versions.

主要是想兼容现有接口，不然发新版本时就得提高大版本号了。