### PR TITLE
compatible with websocket lower case of upgrade in header

### DIFF
--- a/plugins/websocket/ws/http.go
+++ b/plugins/websocket/ws/http.go
@@ -56,10 +56,10 @@ var (
 )
 
 var (
-	specHeaderValueUpgrade    = []byte("websocket")
-	specHeaderValueConnection = []byte("Upgrade")
-	//specHeaderValueConnectionLower = []byte("upgrade")
-	specHeaderValueSecVersion = []byte("13")
+	specHeaderValueUpgrade         = []byte("websocket")
+	specHeaderValueConnection      = []byte("Upgrade")
+	specHeaderValueConnectionLower = []byte("upgrade")
+	specHeaderValueSecVersion      = []byte("13")
 )
 
 var (

--- a/plugins/websocket/ws/ws.go
+++ b/plugins/websocket/ws/ws.go
@@ -256,7 +256,7 @@ func (u *Upgrader) Upgrade(c *connection.Connection, in *ringbuffer.RingBuffer) 
 			}
 		case headerConnectionCanonical:
 			headerSeen |= headerSeenConnection
-			if !bytes.Equal(v, specHeaderValueConnection) {
+			if !bytes.Equal(v, specHeaderValueConnection) && !bytes.Equal(v, specHeaderValueConnectionLower) {
 				err = ErrHandshakeBadConnection
 			}
 		case headerSecVersionCanonical:


### PR DESCRIPTION
gev引用的websocket协议包默认只对 `Upgrade` 兼容, 如果有些客户端发送 `connection: upgrade` 小写则协议升级失败.  看了其他websocket服务端的实现，他们有做大小写兼容。