### PR TITLE
修复eventloop中令人疑惑的注释

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -100,7 +100,7 @@ func (l *EventLoop) EnableReadWrite(fd int) error {
 	return l.poll.EnableReadWrite(fd)
 }
 
-// EnableRead 只注册可写事件
+// EnableRead 只注册可读事件
 func (l *EventLoop) EnableRead(fd int) error {
 	return l.poll.EnableRead(fd)
 }


### PR DESCRIPTION
事件循环中这个注释写的是修改为写就绪事件，但是看poller里面是修改为读就绪事件。
从API的描述看来也是注册读事件的意思。
https://github.com/Allenxuxu/gev/blob/3ac80c576172d936be56d3151c5aed25fb6d837a/poller/epoll.go#L128-L131
https://github.com/Allenxuxu/gev/blob/3ac80c576172d936be56d3151c5aed25fb6d837a/poller/kqueue.go#L110-L124